### PR TITLE
Add VoiceTwine Pterodactyl & Pelican egg

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 * [Redbot](/discord/redbot) Python
 * [Ree6](/discord/ree6) Java
 * [SinusBot](/discord/sinusbot)
+* [VoiceTwine](/discord/voicetwine) Node JS
 
 [Other](/other)
 

--- a/discord/README.md
+++ b/discord/README.md
@@ -67,3 +67,8 @@ All-in-one, open source and 100% free Discord Bot!
 
 [SinusBot](https://www.sinusbot.com/)
 Please Check their site for an in depth on the bot.
+
+### [VoiceTwine](voicetwine)
+
+[Twijn/VoiceTwine](https://github.com/Twijn/VoiceTwine)
+Dynamic voice channel manager for Discord

--- a/discord/voicetwine/README.md
+++ b/discord/voicetwine/README.md
@@ -1,0 +1,55 @@
+# VoiceTwine
+
+___
+
+## Authors / Contributors
+
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+    <tr>
+        <td align="center">
+            <a href="https://github.com/twijn">
+                <img src="https://avatars.githubusercontent.com/u/16090673" width="50px;" alt=""/><br /><sub><b>Twijn</b></sub>
+            </a>
+            <br />
+            <a href="https://github.com/Twijn/VoiceTwine/commits?author=Twijn" title="Codes">💻</a>
+            <a href="https://github.com/Twijn/VoiceTwine/commits?author=Twijn" title="Original Bot Creator">🤖</a>
+            <a href="https://github.com/Twijn/VoiceTwine/commits?author=Twijn" title="Original Egg Creator">🥚</a>
+        </td>
+        <td align="center">
+            <a href="https://github.com/dascanard">
+                <img src="https://avatars.githubusercontent.com/u/17070204" width="50px;" alt=""/><br /><sub><b>DasCanard</b></sub>
+            </a>
+            <br />
+            <a href="https://github.com/Twijn/VoiceTwine/commits?author=DasCanard" title="Codes">💻</a>
+        </td>
+    </tr>
+</table>
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+___
+
+## Bot Description & Features
+
+VoiceTwine is a Discord bot that offers dynamic voice channels. It's intended to be a replacement for Dynamico, EmpyManager, and other bots that require payment for full features.
+
+___
+
+## Configuration
+
+- You will need to configure server variables to start the bot, including operating MariaDB credentials.
+
+___
+
+## Server Ports
+
+There are no ports required for VoiceTwine at this time.
+___
+
+## Updating
+
+Re-Installing the server via the panel will do the following:
+
+1. Update the bot to the latest version.

--- a/discord/voicetwine/egg-pterodactyl-voicetwine.json
+++ b/discord/voicetwine/egg-pterodactyl-voicetwine.json
@@ -1,152 +1,152 @@
 {
-  "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
-  "meta": {
-    "version": "PTDL_v2",
-    "update_url": null
-  },
-  "exported_at": "2025-04-28T17:45:42-04:00",
-  "name": "VoiceTwine",
-  "author": "twijn@twijn.net",
-  "description": "Dynamic voice channel manager for Discord",
-  "features": null,
-  "docker_images": {
-    "Node 22": "ghcr.io\/parkervcp\/yolks:nodejs_22"
-  },
-  "file_denylist": [],
-  "startup": "npm run start",
-  "config": {
-    "files": "{}",
-    "startup": "{\r\n    \"done\": \"App started successfully!\"\r\n}",
-    "logs": "{}",
-    "stop": "^C"
-  },
-  "scripts": {
-    "installation": {
-      "script": "#!\/bin\/bash\r\n# VoiceTwine Installation Script\r\n# Server Files: \/mnt\/server\r\n\r\n# Update system packages\r\napt update\r\napt install -y git curl jq file unzip make gcc g++ python3 python3-dev python3-pip libtool\r\n\r\necho \"Updating npm to latest version...\"\r\nnpm install -g npm@latest\r\n\r\n# Ensure working directory\r\nmkdir -p \/mnt\/server\r\ncd \/mnt\/server\r\n\r\n# Mark the directory as safe to avoid Git \"dubious ownership\" errors\r\ngit config --global --add safe.directory \/mnt\/server\r\n\r\n# Clone or pull the GitHub repository\r\nBRANCH=\"${BRANCH:-master}\"\r\n\r\nif [ \"$(ls -A \/mnt\/server)\" ]; then\r\n    echo \"Directory is not empty.\"\r\n\r\n    if [ -d .git ] && [ -f .git\/config ]; then\r\n        echo \".git directory found, checking remote...\"\r\n        git remote -v\r\n        ORIGIN=$(git config --get remote.origin.url)\r\n\r\n        if [ \"$ORIGIN\" == \"$GIT_ADDRESS\" ]; then\r\n            echo \"Correct repo, pulling latest changes...\"\r\n            git pull origin \"$BRANCH\"\r\n        else\r\n            echo \"Different repo detected. (Current $ORIGIN, getting $GIT_ADDRESS) Exiting to prevent data loss.\"\r\n            exit 10\r\n        fi\r\n    else\r\n        echo \"No .git folder, exiting to avoid overwriting manual files.\"\r\n        exit 10\r\n    fi\r\nelse\r\n    echo \"Directory is empty, cloning repo...\"\r\n    git clone --single-branch --branch \"$BRANCH\" \"$GIT_ADDRESS\" .\r\nfi\r\n\r\n# Install Node.js dependencies\r\nif [ -f package.json ]; then\r\n    echo \"Installing npm dependencies...\"\r\n    npm install --omit=dev\r\n    echo \"Installing typescript and sequelize-cli...\"\r\n    npm install -g typescript sequelize-cli\r\nelse\r\n    echo \"package.json not found! Cannot install dependencies.\"\r\n    exit 20\r\nfi\r\n\r\n# Build the TypeScript code\r\nif [ -f tsconfig.json ]; then\r\n    echo \"Building TypeScript project...\"\r\n    npm run clean # Clean first in case we're updating!\r\n    npm run build\r\nelse\r\n    echo \"tsconfig.json not found! Assuming pre-built or JavaScript project.\"\r\nfi\r\n\r\necho \"Running database migration...\"\r\nnpx sequelize-cli db:migrate\r\n\r\necho \"Installation complete.\"\r\nexit 0",
-      "container": "node:bookworm-slim",
-      "entrypoint": "bash"
-    }
-  },
-  "variables": [
-    {
-      "name": "Node Environment",
-      "description": "The environment setting to use for Node.js",
-      "env_variable": "NODE_ENV",
-      "default_value": "production",
-      "user_viewable": false,
-      "user_editable": false,
-      "rules": "required|string|in:development,production",
-      "field_type": "text"
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
+    "meta": {
+        "version": "PTDL_v2",
+        "update_url": null
     },
-    {
-      "name": "Log Level",
-      "description": "Logging level for VoiceTwine",
-      "env_variable": "LOG_LEVEL",
-      "default_value": "info",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": "required|string|in:debug,info,warn,error",
-      "field_type": "text"
+    "exported_at": "2025-05-21T10:47:46-04:00",
+    "name": "VoiceTwine",
+    "author": "twijn@twijn.net",
+    "description": "Dynamic voice channel manager for Discord",
+    "features": null,
+    "docker_images": {
+        "Node 22": "ghcr.io\/parkervcp\/yolks:nodejs_22"
     },
-    {
-      "name": "MariaDB Host",
-      "description": "MariaDB server host address",
-      "env_variable": "MARIADB_HOST",
-      "default_value": "172.18.0.1",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": "required|string",
-      "field_type": "text"
+    "file_denylist": [],
+    "startup": "npm run start",
+    "config": {
+        "files": "{}",
+        "startup": "{\r\n    \"done\": \"App started successfully!\"\r\n}",
+        "logs": "{}",
+        "stop": "^C"
     },
-    {
-      "name": "MariaDB Port",
-      "description": "MariaDB server port",
-      "env_variable": "MARIADB_PORT",
-      "default_value": "3306",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": "required|numeric",
-      "field_type": "text"
+    "scripts": {
+        "installation": {
+            "script": "#!\/bin\/bash\r\n# VoiceTwine Installation Script\r\n# Server Files: \/mnt\/server\r\n\r\n# Update system packages\r\napt update\r\napt install -y git curl jq file unzip make gcc g++ python3 python3-dev python3-pip libtool\r\n\r\necho \"Updating npm to latest version...\"\r\nnpm install -g npm@latest\r\n\r\n# Ensure working directory\r\nmkdir -p \/mnt\/server\r\ncd \/mnt\/server\r\n\r\n# Mark the directory as safe to avoid Git \"dubious ownership\" errors\r\ngit config --global --add safe.directory \/mnt\/server\r\n\r\n# Clone or pull the GitHub repository\r\nBRANCH=\"${BRANCH:-master}\"\r\n\r\nif [ \"$(ls -A \/mnt\/server)\" ]; then\r\n    echo \"Directory is not empty.\"\r\n\r\n    if [ -d .git ] && [ -f .git\/config ]; then\r\n        echo \".git directory found, checking remote...\"\r\n        git remote -v\r\n        ORIGIN=$(git config --get remote.origin.url)\r\n\r\n        if [ \"$ORIGIN\" == \"$GIT_ADDRESS\" ]; then\r\n            echo \"Correct repo, pulling latest changes...\"\r\n            git pull origin \"$BRANCH\"\r\n        else\r\n            echo \"Different repo detected. (Current $ORIGIN, getting $GIT_ADDRESS) Exiting to prevent data loss.\"\r\n            exit 10\r\n        fi\r\n    else\r\n        echo \"No .git folder, exiting to avoid overwriting manual files.\"\r\n        exit 10\r\n    fi\r\nelse\r\n    echo \"Directory is empty, cloning repo...\"\r\n    git clone --single-branch --branch \"$BRANCH\" \"$GIT_ADDRESS\" .\r\nfi\r\n\r\n# Install Node.js dependencies\r\nif [ -f package.json ]; then\r\n    echo \"Installing npm dependencies...\"\r\n    npm install --omit=dev\r\n    echo \"Installing typescript and sequelize-cli...\"\r\n    npm install -g typescript sequelize-cli\r\nelse\r\n    echo \"package.json not found! Cannot install dependencies.\"\r\n    exit 20\r\nfi\r\n\r\n# Build the TypeScript code\r\nif [ -f tsconfig.json ]; then\r\n    echo \"Building TypeScript project...\"\r\n    npm run clean # Clean first in case we're updating!\r\n    npm run build\r\nelse\r\n    echo \"tsconfig.json not found! Assuming pre-built or JavaScript project.\"\r\nfi\r\n\r\necho \"Running database migration...\"\r\nnpx sequelize-cli db:migrate\r\n\r\necho \"Installation complete.\"\r\nexit 0",
+            "container": "node:bookworm-slim",
+            "entrypoint": "bash"
+        }
     },
-    {
-      "name": "MariaDB User",
-      "description": "MariaDB username",
-      "env_variable": "MARIADB_USER",
-      "default_value": "voicetwine",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": "required|string",
-      "field_type": "text"
-    },
-    {
-      "name": "MariaDB Password",
-      "description": "MariaDB password",
-      "env_variable": "MARIADB_PASS",
-      "default_value": "",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": "required|string",
-      "field_type": "text"
-    },
-    {
-      "name": "MariaDB Database",
-      "description": "MariaDB schema name",
-      "env_variable": "MARIADB_DB",
-      "default_value": "voicetwine",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": "required|string",
-      "field_type": "text"
-    },
-    {
-      "name": "Discord Client ID",
-      "description": "Discord client ID, retrieved from the Developer panel",
-      "env_variable": "DISCORD_CLIENT_ID",
-      "default_value": "",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": "required|string",
-      "field_type": "text"
-    },
-    {
-      "name": "Discord Client Secret",
-      "description": "Discord client secret, retrieved from the Developer panel",
-      "env_variable": "DISCORD_CLIENT_SECRET",
-      "default_value": "",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": "required|string",
-      "field_type": "text"
-    },
-    {
-      "name": "Discord Token",
-      "description": "Discord bot token, retrieved from the Developer panel",
-      "env_variable": "DISCORD_TOKEN",
-      "default_value": "",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": "required|string",
-      "field_type": "text"
-    },
-    {
-      "name": "GitHub Address",
-      "description": "The GitHub address for VoiceTwine. Defaults to the main repo, but can be changed to a custom one.",
-      "env_variable": "GIT_ADDRESS",
-      "default_value": "https:\/\/github.com\/Twijn\/VoiceTwine.git",
-      "user_viewable": true,
-      "user_editable": false,
-      "rules": "required|string",
-      "field_type": "text"
-    },
-    {
-      "name": "GitHub Branch",
-      "description": "The branch to use from GitHub",
-      "env_variable": "BRANCH",
-      "default_value": "master",
-      "user_viewable": true,
-      "user_editable": false,
-      "rules": "required|string",
-      "field_type": "text"
-    }
-  ]
+    "variables": [
+        {
+            "name": "Node Environment",
+            "description": "The environment setting to use for Node.js",
+            "env_variable": "NODE_ENV",
+            "default_value": "production",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|string|in:development,production",
+            "field_type": "text"
+        },
+        {
+            "name": "Log Level",
+            "description": "Logging level for VoiceTwine",
+            "env_variable": "LOG_LEVEL",
+            "default_value": "info",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|in:debug,info,warn,error",
+            "field_type": "text"
+        },
+        {
+            "name": "MariaDB Host",
+            "description": "MariaDB server host address",
+            "env_variable": "MARIADB_HOST",
+            "default_value": "172.18.0.1",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "string",
+            "field_type": "text"
+        },
+        {
+            "name": "MariaDB Port",
+            "description": "MariaDB server port",
+            "env_variable": "MARIADB_PORT",
+            "default_value": "3306",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "numeric",
+            "field_type": "text"
+        },
+        {
+            "name": "MariaDB User",
+            "description": "MariaDB username",
+            "env_variable": "MARIADB_USER",
+            "default_value": "voicetwine",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "string",
+            "field_type": "text"
+        },
+        {
+            "name": "MariaDB Password",
+            "description": "MariaDB password",
+            "env_variable": "MARIADB_PASS",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "string",
+            "field_type": "text"
+        },
+        {
+            "name": "MariaDB Database",
+            "description": "MariaDB schema name",
+            "env_variable": "MARIADB_DB",
+            "default_value": "s1_voicetwine",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "string",
+            "field_type": "text"
+        },
+        {
+            "name": "Discord Client ID",
+            "description": "Discord client ID, retrieved from the Developer panel",
+            "env_variable": "DISCORD_CLIENT_ID",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|numeric",
+            "field_type": "text"
+        },
+        {
+            "name": "Discord Client Secret",
+            "description": "Discord client secret, retrieved from the Developer panel",
+            "env_variable": "DISCORD_CLIENT_SECRET",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string",
+            "field_type": "text"
+        },
+        {
+            "name": "Discord Token",
+            "description": "Discord bot token, retrieved from the Developer panel",
+            "env_variable": "DISCORD_TOKEN",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string",
+            "field_type": "text"
+        },
+        {
+            "name": "GitHub Address",
+            "description": "The GitHub address for VoiceTwine. Defaults to the main repo, but can be changed to a custom one.",
+            "env_variable": "GIT_ADDRESS",
+            "default_value": "https:\/\/github.com\/Twijn\/VoiceTwine.git",
+            "user_viewable": true,
+            "user_editable": false,
+            "rules": "required|string",
+            "field_type": "text"
+        },
+        {
+            "name": "GitHub Branch",
+            "description": "The branch to use from GitHub",
+            "env_variable": "BRANCH",
+            "default_value": "master",
+            "user_viewable": true,
+            "user_editable": false,
+            "rules": "required|string",
+            "field_type": "text"
+        }
+    ]
 }

--- a/discord/voicetwine/egg-pterodactyl-voicetwine.json
+++ b/discord/voicetwine/egg-pterodactyl-voicetwine.json
@@ -1,0 +1,152 @@
+{
+  "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
+  "meta": {
+    "version": "PTDL_v2",
+    "update_url": null
+  },
+  "exported_at": "2025-04-28T17:45:42-04:00",
+  "name": "VoiceTwine",
+  "author": "twijn@twijn.net",
+  "description": "Dynamic voice channel manager for Discord",
+  "features": null,
+  "docker_images": {
+    "Node 22": "ghcr.io\/parkervcp\/yolks:nodejs_22"
+  },
+  "file_denylist": [],
+  "startup": "npm run start",
+  "config": {
+    "files": "{}",
+    "startup": "{\r\n    \"done\": \"App started successfully!\"\r\n}",
+    "logs": "{}",
+    "stop": "^C"
+  },
+  "scripts": {
+    "installation": {
+      "script": "#!\/bin\/bash\r\n# VoiceTwine Installation Script\r\n# Server Files: \/mnt\/server\r\n\r\n# Update system packages\r\napt update\r\napt install -y git curl jq file unzip make gcc g++ python3 python3-dev python3-pip libtool\r\n\r\necho \"Updating npm to latest version...\"\r\nnpm install -g npm@latest\r\n\r\n# Ensure working directory\r\nmkdir -p \/mnt\/server\r\ncd \/mnt\/server\r\n\r\n# Mark the directory as safe to avoid Git \"dubious ownership\" errors\r\ngit config --global --add safe.directory \/mnt\/server\r\n\r\n# Clone or pull the GitHub repository\r\nBRANCH=\"${BRANCH:-master}\"\r\n\r\nif [ \"$(ls -A \/mnt\/server)\" ]; then\r\n    echo \"Directory is not empty.\"\r\n\r\n    if [ -d .git ] && [ -f .git\/config ]; then\r\n        echo \".git directory found, checking remote...\"\r\n        git remote -v\r\n        ORIGIN=$(git config --get remote.origin.url)\r\n\r\n        if [ \"$ORIGIN\" == \"$GIT_ADDRESS\" ]; then\r\n            echo \"Correct repo, pulling latest changes...\"\r\n            git pull origin \"$BRANCH\"\r\n        else\r\n            echo \"Different repo detected. (Current $ORIGIN, getting $GIT_ADDRESS) Exiting to prevent data loss.\"\r\n            exit 10\r\n        fi\r\n    else\r\n        echo \"No .git folder, exiting to avoid overwriting manual files.\"\r\n        exit 10\r\n    fi\r\nelse\r\n    echo \"Directory is empty, cloning repo...\"\r\n    git clone --single-branch --branch \"$BRANCH\" \"$GIT_ADDRESS\" .\r\nfi\r\n\r\n# Install Node.js dependencies\r\nif [ -f package.json ]; then\r\n    echo \"Installing npm dependencies...\"\r\n    npm install --omit=dev\r\n    echo \"Installing typescript and sequelize-cli...\"\r\n    npm install -g typescript sequelize-cli\r\nelse\r\n    echo \"package.json not found! Cannot install dependencies.\"\r\n    exit 20\r\nfi\r\n\r\n# Build the TypeScript code\r\nif [ -f tsconfig.json ]; then\r\n    echo \"Building TypeScript project...\"\r\n    npm run clean # Clean first in case we're updating!\r\n    npm run build\r\nelse\r\n    echo \"tsconfig.json not found! Assuming pre-built or JavaScript project.\"\r\nfi\r\n\r\necho \"Running database migration...\"\r\nnpx sequelize-cli db:migrate\r\n\r\necho \"Installation complete.\"\r\nexit 0",
+      "container": "node:bookworm-slim",
+      "entrypoint": "bash"
+    }
+  },
+  "variables": [
+    {
+      "name": "Node Environment",
+      "description": "The environment setting to use for Node.js",
+      "env_variable": "NODE_ENV",
+      "default_value": "production",
+      "user_viewable": false,
+      "user_editable": false,
+      "rules": "required|string|in:development,production",
+      "field_type": "text"
+    },
+    {
+      "name": "Log Level",
+      "description": "Logging level for VoiceTwine",
+      "env_variable": "LOG_LEVEL",
+      "default_value": "info",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "required|string|in:debug,info,warn,error",
+      "field_type": "text"
+    },
+    {
+      "name": "MariaDB Host",
+      "description": "MariaDB server host address",
+      "env_variable": "MARIADB_HOST",
+      "default_value": "172.18.0.1",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "required|string",
+      "field_type": "text"
+    },
+    {
+      "name": "MariaDB Port",
+      "description": "MariaDB server port",
+      "env_variable": "MARIADB_PORT",
+      "default_value": "3306",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "required|numeric",
+      "field_type": "text"
+    },
+    {
+      "name": "MariaDB User",
+      "description": "MariaDB username",
+      "env_variable": "MARIADB_USER",
+      "default_value": "voicetwine",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "required|string",
+      "field_type": "text"
+    },
+    {
+      "name": "MariaDB Password",
+      "description": "MariaDB password",
+      "env_variable": "MARIADB_PASS",
+      "default_value": "",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "required|string",
+      "field_type": "text"
+    },
+    {
+      "name": "MariaDB Database",
+      "description": "MariaDB schema name",
+      "env_variable": "MARIADB_DB",
+      "default_value": "voicetwine",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "required|string",
+      "field_type": "text"
+    },
+    {
+      "name": "Discord Client ID",
+      "description": "Discord client ID, retrieved from the Developer panel",
+      "env_variable": "DISCORD_CLIENT_ID",
+      "default_value": "",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "required|string",
+      "field_type": "text"
+    },
+    {
+      "name": "Discord Client Secret",
+      "description": "Discord client secret, retrieved from the Developer panel",
+      "env_variable": "DISCORD_CLIENT_SECRET",
+      "default_value": "",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "required|string",
+      "field_type": "text"
+    },
+    {
+      "name": "Discord Token",
+      "description": "Discord bot token, retrieved from the Developer panel",
+      "env_variable": "DISCORD_TOKEN",
+      "default_value": "",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "required|string",
+      "field_type": "text"
+    },
+    {
+      "name": "GitHub Address",
+      "description": "The GitHub address for VoiceTwine. Defaults to the main repo, but can be changed to a custom one.",
+      "env_variable": "GIT_ADDRESS",
+      "default_value": "https:\/\/github.com\/Twijn\/VoiceTwine.git",
+      "user_viewable": true,
+      "user_editable": false,
+      "rules": "required|string",
+      "field_type": "text"
+    },
+    {
+      "name": "GitHub Branch",
+      "description": "The branch to use from GitHub",
+      "env_variable": "BRANCH",
+      "default_value": "master",
+      "user_viewable": true,
+      "user_editable": false,
+      "rules": "required|string",
+      "field_type": "text"
+    }
+  ]
+}

--- a/discord/voicetwine/egg-voicetwine.json
+++ b/discord/voicetwine/egg-voicetwine.json
@@ -4,13 +4,13 @@
         "version": "PLCN_v1",
         "update_url": null
     },
-    "exported_at": "2025-05-20T18:45:37+00:00",
+    "exported_at": "2025-05-21T14:50:45+00:00",
     "name": "VoiceTwine",
     "author": "twijn@twijn.net",
     "uuid": "966787cb-eb63-467a-ac4b-52d8de0c9d5c",
     "description": "Dynamic voice channel manager for Discord",
     "tags": [],
-    "features": null,
+    "features": [],
     "docker_images": {
         "Node 22": "ghcr.io\/parkervcp\/yolks:nodejs_22"
     },
@@ -31,7 +31,7 @@
     },
     "variables": [
         {
-            "sort": null,
+            "sort": 12,
             "name": "GitHub Branch",
             "description": "The branch to use from GitHub",
             "env_variable": "BRANCH",
@@ -44,7 +44,7 @@
             ]
         },
         {
-            "sort": null,
+            "sort": 8,
             "name": "Discord Client ID",
             "description": "Discord client ID, retrieved from the Developer panel",
             "env_variable": "DISCORD_CLIENT_ID",
@@ -53,11 +53,11 @@
             "user_editable": true,
             "rules": [
                 "required",
-                "string"
+                "numeric"
             ]
         },
         {
-            "sort": null,
+            "sort": 9,
             "name": "Discord Client Secret",
             "description": "Discord client secret, retrieved from the Developer panel",
             "env_variable": "DISCORD_CLIENT_SECRET",
@@ -70,7 +70,7 @@
             ]
         },
         {
-            "sort": null,
+            "sort": 10,
             "name": "Discord Token",
             "description": "Discord bot token, retrieved from the Developer panel",
             "env_variable": "DISCORD_TOKEN",
@@ -83,7 +83,7 @@
             ]
         },
         {
-            "sort": null,
+            "sort": 11,
             "name": "GitHub Address",
             "description": "The GitHub address for VoiceTwine. Defaults to the main repo, but can be changed to a custom one.",
             "env_variable": "GIT_ADDRESS",
@@ -96,7 +96,7 @@
             ]
         },
         {
-            "sort": null,
+            "sort": 2,
             "name": "Log Level",
             "description": "Logging level for VoiceTwine",
             "env_variable": "LOG_LEVEL",
@@ -110,20 +110,19 @@
             ]
         },
         {
-            "sort": null,
+            "sort": 7,
             "name": "MariaDB Database",
             "description": "MariaDB schema name",
             "env_variable": "MARIADB_DB",
-            "default_value": "voicetwine",
+            "default_value": "s1_voicetwine",
             "user_viewable": true,
             "user_editable": true,
             "rules": [
-                "required",
                 "string"
             ]
         },
         {
-            "sort": null,
+            "sort": 3,
             "name": "MariaDB Host",
             "description": "MariaDB server host address",
             "env_variable": "MARIADB_HOST",
@@ -131,12 +130,11 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": [
-                "required",
                 "string"
             ]
         },
         {
-            "sort": null,
+            "sort": 6,
             "name": "MariaDB Password",
             "description": "MariaDB password",
             "env_variable": "MARIADB_PASS",
@@ -144,12 +142,11 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": [
-                "required",
                 "string"
             ]
         },
         {
-            "sort": null,
+            "sort": 4,
             "name": "MariaDB Port",
             "description": "MariaDB server port",
             "env_variable": "MARIADB_PORT",
@@ -157,12 +154,11 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": [
-                "required",
                 "numeric"
             ]
         },
         {
-            "sort": null,
+            "sort": 5,
             "name": "MariaDB User",
             "description": "MariaDB username",
             "env_variable": "MARIADB_USER",
@@ -170,12 +166,11 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": [
-                "required",
                 "string"
             ]
         },
         {
-            "sort": null,
+            "sort": 1,
             "name": "Node Environment",
             "description": "The environment setting to use for Node.js",
             "env_variable": "NODE_ENV",

--- a/discord/voicetwine/egg-voicetwine.json
+++ b/discord/voicetwine/egg-voicetwine.json
@@ -1,0 +1,192 @@
+{
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
+    "meta": {
+        "version": "PLCN_v1",
+        "update_url": null
+    },
+    "exported_at": "2025-05-20T18:45:37+00:00",
+    "name": "VoiceTwine",
+    "author": "twijn@twijn.net",
+    "uuid": "966787cb-eb63-467a-ac4b-52d8de0c9d5c",
+    "description": "Dynamic voice channel manager for Discord",
+    "tags": [],
+    "features": null,
+    "docker_images": {
+        "Node 22": "ghcr.io\/parkervcp\/yolks:nodejs_22"
+    },
+    "file_denylist": [],
+    "startup": "npm run start",
+    "config": {
+        "files": "{}",
+        "startup": "{\r\n    \"done\": \"App started successfully!\"\r\n}",
+        "logs": "{}",
+        "stop": "^C"
+    },
+    "scripts": {
+        "installation": {
+            "script": "#!\/bin\/bash\r\n# VoiceTwine Installation Script\r\n# Server Files: \/mnt\/server\r\n\r\n# Update system packages\r\napt update\r\napt install -y git curl jq file unzip make gcc g++ python3 python3-dev python3-pip libtool\r\n\r\necho \"Updating npm to latest version...\"\r\nnpm install -g npm@latest\r\n\r\n# Ensure working directory\r\nmkdir -p \/mnt\/server\r\ncd \/mnt\/server\r\n\r\n# Mark the directory as safe to avoid Git \"dubious ownership\" errors\r\ngit config --global --add safe.directory \/mnt\/server\r\n\r\n# Clone or pull the GitHub repository\r\nBRANCH=\"${BRANCH:-master}\"\r\n\r\nif [ \"$(ls -A \/mnt\/server)\" ]; then\r\n    echo \"Directory is not empty.\"\r\n\r\n    if [ -d .git ] && [ -f .git\/config ]; then\r\n        echo \".git directory found, checking remote...\"\r\n        git remote -v\r\n        ORIGIN=$(git config --get remote.origin.url)\r\n\r\n        if [ \"$ORIGIN\" == \"$GIT_ADDRESS\" ]; then\r\n            echo \"Correct repo, pulling latest changes...\"\r\n            git pull origin \"$BRANCH\"\r\n        else\r\n            echo \"Different repo detected. (Current $ORIGIN, getting $GIT_ADDRESS) Exiting to prevent data loss.\"\r\n            exit 10\r\n        fi\r\n    else\r\n        echo \"No .git folder, exiting to avoid overwriting manual files.\"\r\n        exit 10\r\n    fi\r\nelse\r\n    echo \"Directory is empty, cloning repo...\"\r\n    git clone --single-branch --branch \"$BRANCH\" \"$GIT_ADDRESS\" .\r\nfi\r\n\r\n# Install Node.js dependencies\r\nif [ -f package.json ]; then\r\n    echo \"Installing npm dependencies...\"\r\n    npm install --omit=dev\r\n    echo \"Installing typescript and sequelize-cli...\"\r\n    npm install -g typescript sequelize-cli\r\nelse\r\n    echo \"package.json not found! Cannot install dependencies.\"\r\n    exit 20\r\nfi\r\n\r\n# Build the TypeScript code\r\nif [ -f tsconfig.json ]; then\r\n    echo \"Building TypeScript project...\"\r\n    npm run clean # Clean first in case we're updating!\r\n    npm run build\r\nelse\r\n    echo \"tsconfig.json not found! Assuming pre-built or JavaScript project.\"\r\nfi\r\n\r\necho \"Running database migration...\"\r\nnpx sequelize-cli db:migrate\r\n\r\necho \"Installation complete.\"\r\nexit 0",
+            "container": "node:bookworm-slim",
+            "entrypoint": "bash"
+        }
+    },
+    "variables": [
+        {
+            "sort": null,
+            "name": "GitHub Branch",
+            "description": "The branch to use from GitHub",
+            "env_variable": "BRANCH",
+            "default_value": "master",
+            "user_viewable": true,
+            "user_editable": false,
+            "rules": [
+                "required",
+                "string"
+            ]
+        },
+        {
+            "sort": null,
+            "name": "Discord Client ID",
+            "description": "Discord client ID, retrieved from the Developer panel",
+            "env_variable": "DISCORD_CLIENT_ID",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "string"
+            ]
+        },
+        {
+            "sort": null,
+            "name": "Discord Client Secret",
+            "description": "Discord client secret, retrieved from the Developer panel",
+            "env_variable": "DISCORD_CLIENT_SECRET",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "string"
+            ]
+        },
+        {
+            "sort": null,
+            "name": "Discord Token",
+            "description": "Discord bot token, retrieved from the Developer panel",
+            "env_variable": "DISCORD_TOKEN",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "string"
+            ]
+        },
+        {
+            "sort": null,
+            "name": "GitHub Address",
+            "description": "The GitHub address for VoiceTwine. Defaults to the main repo, but can be changed to a custom one.",
+            "env_variable": "GIT_ADDRESS",
+            "default_value": "https:\/\/github.com\/Twijn\/VoiceTwine.git",
+            "user_viewable": true,
+            "user_editable": false,
+            "rules": [
+                "required",
+                "string"
+            ]
+        },
+        {
+            "sort": null,
+            "name": "Log Level",
+            "description": "Logging level for VoiceTwine",
+            "env_variable": "LOG_LEVEL",
+            "default_value": "info",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "string",
+                "in:debug,info,warn,error"
+            ]
+        },
+        {
+            "sort": null,
+            "name": "MariaDB Database",
+            "description": "MariaDB schema name",
+            "env_variable": "MARIADB_DB",
+            "default_value": "voicetwine",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "string"
+            ]
+        },
+        {
+            "sort": null,
+            "name": "MariaDB Host",
+            "description": "MariaDB server host address",
+            "env_variable": "MARIADB_HOST",
+            "default_value": "172.18.0.1",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "string"
+            ]
+        },
+        {
+            "sort": null,
+            "name": "MariaDB Password",
+            "description": "MariaDB password",
+            "env_variable": "MARIADB_PASS",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "string"
+            ]
+        },
+        {
+            "sort": null,
+            "name": "MariaDB Port",
+            "description": "MariaDB server port",
+            "env_variable": "MARIADB_PORT",
+            "default_value": "3306",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "numeric"
+            ]
+        },
+        {
+            "sort": null,
+            "name": "MariaDB User",
+            "description": "MariaDB username",
+            "env_variable": "MARIADB_USER",
+            "default_value": "voicetwine",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "string"
+            ]
+        },
+        {
+            "sort": null,
+            "name": "Node Environment",
+            "description": "The environment setting to use for Node.js",
+            "env_variable": "NODE_ENV",
+            "default_value": "production",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": [
+                "required",
+                "string",
+                "in:development,production"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Adds the VoiceTwine discord bot Pterodactyl and Pelican exported eggs, a modification of the generic nodejs egg to include startup variables for .env application variables.

## Checklist for all submissions

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?: N/A

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel

## New egg Submissions

1. [x] Does your submission pass tests (server is connectable)?
2. [ ] Does your egg use a custom docker image?
    * [ ] Have you tried to use a generic image?
    * [ ] Did you PR the necessary changes to make it work?
3. [x] Have you added the egg to the main README.md and any other README files in subdirectories of the egg (e.g /game_eggs) according to the alphabetical order?
4. [x] Have you added a unique README.md for the egg you are adding according to the alphabetical order?
5. [x] You verify that the start command applied does not use a shell script
    * [ ] If some script is needed then it is part of a current yolk or a PR to add one
6. [x] The egg was exported from the panel